### PR TITLE
Change snapshot schedule

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,7 +96,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
-        consensus.BTPHeight = 498533; // Around 12/12/2017 UTC
+        consensus.BTPHeight = 600000; // Around 12/X/2017 UTC
         consensus.BTPDiffdropWindow = 100;
         consensus.BitcoinPostforkBlock = uint256();
         consensus.BitcoinPostforkTime = 2008808039;


### PR DESCRIPTION
 Currently Bitcoin Platinum is suspected of fraud. Please delay the snapshot schedule